### PR TITLE
fix: test-workflow-dryrun: avoid duplicate test names

### DIFF
--- a/tests/testthat/test-workflow-dryrun.R
+++ b/tests/testthat/test-workflow-dryrun.R
@@ -33,7 +33,9 @@ withr::with_options(list(rbabylon.model_directory = normalizePath(MODEL_DIR)), {
   readr::write_file("created_by: test-workflow-dryrun part 1", bbi_yaml)
 
   for (.test_case in .TEST_CASES_WD) {
-    test_that(paste0("basic workflow is correct using rbabylon.model_directory = '", MODEL_DIR, "'", if(isTRUE(.test_case$change_midstream)) " change_midstream"), {
+    test_that(paste0("basic workflow is correct using rbabylon.model_directory = '",
+                     MODEL_DIR, "'", .test_case$test_wd,
+                     if(isTRUE(.test_case$change_midstream)) " change_midstream"), {
       withr::with_dir(.test_case$test_wd, {
 
         # load model from yaml


### PR DESCRIPTION
test-workflow-dryrun.R loops over combinations of test_wd and
change_midstream values, generating the test_that() names.  Some of
these names collide:

    > test_df$TestName[duplicated(test_df$TestName)]
    [1] "basic workflow is correct using rbabylon.model_directory = 'model-examples'"
    [2] "basic workflow is correct using rbabylon.model_directory = 'model-examples'"
    [3] "basic workflow is correct using rbabylon.model_directory = 'model-examples' change_midstream"
    [4] "basic workflow is correct using rbabylon.model_directory = 'model-examples' change_midstream"

This causes issues with the upcoming mrgvalidate because it relies on
the test names being unique when a set of tests haven't been marked
with a test ID.

Add test_wd to the name (matching what's done elsewhere) so that the
test name is unique.